### PR TITLE
ghc-9.2 dependency support

### DIFF
--- a/lib/Network/Pcap/Streaming.hs
+++ b/lib/Network/Pcap/Streaming.hs
@@ -17,11 +17,11 @@ module Network.Pcap.Streaming
 
 import           Control.Monad.Trans.Resource
 import qualified Data.Attoparsec.ByteString.Streaming as A
-import qualified Data.ByteString.Streaming as Q
 import           Data.Int (Int64)
 import           Network.Pcap
 import           Network.Pcap.Streaming.Internal
 import           Streaming
+import qualified Streaming.ByteString as Q
 import qualified Streaming.Prelude as P
 
 ---

--- a/streaming-pcap.cabal
+++ b/streaming-pcap.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               streaming-pcap
-version:            1.1.1.1
+version:            1.1.1.2
 synopsis:           Stream packets via libpcap.
 description:
   Stream packets via libpcap. Requires `libpcap` to be installed.
@@ -18,18 +18,22 @@ extra-source-files:
   CHANGELOG.md
   test/test.pcap
 
+common warnings
+    ghc-options: -Weverything
+                 -Wno-all-missed-specialisations
+
 common commons
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-    , attoparsec            ^>=0.13
+      attoparsec            ^>=0.13 || ^>=0.14
     , base                  >=4.8  && <5
     , bytestring
     , pcap                  ^>=0.4
     , resourcet             ^>=1.2
     , streaming             >=0.1  && <0.3
     , streaming-attoparsec  ^>=1.0
-    , streaming-bytestring  ^>=0.1
+    , streaming-bytestring  ^>=0.1.7
 
 library
   import:          commons


### PR DESCRIPTION
The newer base ends up requiring a newer attoparsec.

_**streaming-bytestring**_ deprecated `Data.ByteString.Streaming` in favor of `Streaming.ByteString` at 0.1.7. With extra warnings enabled, this throws a deprecation notice.

Tested with:

 * `cabal test`
 * cabal version 3.8.1.0
 * The Glorious Glasgow Haskell Compilation System, version 9.2.7
 * macOS